### PR TITLE
add cec toggle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ TeX is a new web interface for Kodi made with Angular and Tailwind CSS.
 - Play musics in your browser
 - Download medias directly from your browser
 - Manage some Kodi settings
+- Toggle CEC state (if the [script.json-cec](https://github.com/joshjowen/script.json-cec) addon is installed)
 
 ## Installation
 

--- a/src/app/components/remote/remote.component.html
+++ b/src/app/components/remote/remote.component.html
@@ -23,7 +23,7 @@
                     <div class="flex flex-col w-full">
                         <div class="flex flex-row w-full h-full items-center">
                             <button><fa-icon [icon]="['fas', 'volume-down']" class="button-primary" (click)="onInputVolumeDown()"></fa-icon></button>
-                            <button></button>
+                            <button><fa-icon *ngIf="cecEnabled" [icon]="['fas', 'power-off']" class="button-primary" (click)="onCecToggle()"></fa-icon></button>
                             <button><fa-icon [icon]="['fas', 'volume-up']" class="button-primary" (click)="onInputVolumeUp()"></fa-icon></button>
                         </div>
                         <div [ngClass]="{'opacity-100' : displayVolumeBar}" class="relative pt-1 w-full px-8 mt-2 opacity-0 transition-opacity duration-100">

--- a/src/app/components/remote/remote.component.ts
+++ b/src/app/components/remote/remote.component.ts
@@ -19,6 +19,7 @@ import { LocalStorageService } from 'src/app/services/local-storage.service';
 export class RemoteComponent implements OnInit {
 
   displayVolumeBar: boolean = false;
+  cecEnabled: boolean = false;
 
   private volumeBarDelay:number = 0;
   sendTextValue = ""
@@ -31,6 +32,11 @@ export class RemoteComponent implements OnInit {
   ngOnInit(): void {
     this.document.body.style.overflow = "hidden";  
     this.application.historyPush("remote");
+    this.kodiApi.remote.cecEnabled().subscribe((response) => {
+      if (response?.addon?.enabled === true) {
+        this.cecEnabled = true;
+      }
+    });
   }
 
   ngOnDestroy(): void {
@@ -136,6 +142,10 @@ export class RemoteComponent implements OnInit {
     const vibrationLength:number = this.localStorage.getData("vibrate") ?? 50
     if(vibrationLength > 0)
       window.navigator.vibrate(vibrationLength); 
+  }
+
+  onCecToggle() {
+    this.kodiApi.remote.cecCommand("toggle")
   }
 
 }

--- a/src/app/services/protocol/http/remote.ts
+++ b/src/app/services/protocol/http/remote.ts
@@ -1,7 +1,10 @@
 import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs/internal/Observable";
 import { HttpRequestData } from "./http";
 
 export class RemoteRequest extends HttpRequestData {
+
+    private cecAddonID = "script.json-cec";
 
     constructor(http:HttpClient){
         super(http)
@@ -62,6 +65,14 @@ export class RemoteRequest extends HttpRequestData {
         this.makePostRequest(req).subscribe();
     }
 
+    cecCommand(command: string) {
+        const req = this.getRequestParams("cec", "Addons.ExecuteAddon", { "addonid": this.cecAddonID, "params": { "command": command } })
+        this.makePostRequest(req).subscribe();
+    }
     
+    cecEnabled(): Observable<any> {
+        const req = this.getRequestParams("cec", "Addons.GetAddonDetails", { "addonid": this.cecAddonID, "properties": ["enabled"] })
+        return this.makePostRequest(req);
+    }
 
 }


### PR DESCRIPTION
These changes add a power button which executes the [CECToggleState](https://kodi.wiki/view/List_of_built-in_functions#CEC_built-in.27s) builtin function if an addon called `script.json-cec` is installed. This allows, e.g., toggling power to a display over HDMI.