### PR TITLE
create separate remote modal component

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,23 +8,24 @@ import { MusicsComponent } from './components/libraries/musics/musics.component'
 import { LibraryCategoryComponent } from './components/libraries/menu/category/category.component';
 import { MoviesHomeComponent } from './components/libraries/movies/home/home.component';
 import { TvShowsHomeComponent } from './components/libraries/tvshows/home/home.component';
+import { RemoteComponent } from './components/remote/remote.component';
 
 const routes: Routes = [
-  
+
   {
     path:'movies',
-    component: MoviesComponent,  
+    component: MoviesComponent,
     children:[
       {
-        path:'',  
+        path:'',
         component:MoviesHomeComponent
       },
       {
-        path:'home',  
+        path:'home',
         component:MoviesHomeComponent
       },
       {
-        path:':type',   
+        path:':type',
         component:LibraryCategoryComponent
       }
     ]
@@ -43,15 +44,15 @@ const routes: Routes = [
     component: TvshowsComponent,
     children:[
       {
-        path:'',  
+        path:'',
         component:TvShowsHomeComponent
       },
       {
-        path:'home',  
+        path:'home',
         component:TvShowsHomeComponent
       },
       {
-        path:':type',   
+        path:':type',
         component:LibraryCategoryComponent
       }
     ]
@@ -117,10 +118,10 @@ const routes: Routes = [
         ]
       },
     ]
-  }, 
+  },
   {
     path:'search',
-    component: SearchComponent,  
+    component: SearchComponent,
   },
   {
     path:'settings',
@@ -143,6 +144,10 @@ const routes: Routes = [
         component: SettingsComponent
       },
     ]
+  },
+  {
+    path:'remote',
+    component: RemoteComponent,
   },
   {
     path:'',

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,8 +4,8 @@
 
 <router-outlet></router-outlet>
 
-<app-remote class="sm:hidden fixed bottom-0 left-0 w-screen h-screen z-40" @modalAnimationReverse *ngIf="application.openRemote"></app-remote>
-<app-remote class="fixed bottom-0 left-0 w-screen h-screen hidden sm:block z-40" @modalAnimation *ngIf="application.openRemote"></app-remote>
+<remote-modal class="sm:hidden fixed bottom-0 left-0 w-screen h-screen z-40" @modalAnimationReverse *ngIf="application.openRemote"></remote-modal>
+<remote-modal class="fixed bottom-0 left-0 w-screen h-screen hidden sm:block z-40" @modalAnimation *ngIf="application.openRemote"></remote-modal>
 
 <app-media-informations class="fixed bottom-0 left-0 w-screen h-screen sm:block z-40" @modalAnimation *ngIf="application.openMovieDetails || application.openTVShowDetails"></app-media-informations>
 <app-notifications></app-notifications>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { MovieInformationComponent } from './components/media-informations/movie
 import { TvshowInformationComponent } from './components/media-informations/tvshow-information/tvshow-information.component';
 import { EpisodeComponent } from './components/media-informations/tvshow-information/episode/episode.component';
 import { RemoteComponent } from './components/remote/remote.component';
+import { ModalComponent } from './components/modal/modal.component';
 import { PlaylistItemComponent } from './components/header/player/playlist-item/playlist-item.component';
 import { SearchComponent } from './components/libraries/search/search.component';
 import { SearchbarComponent } from './components/header/searchbar/searchbar.component';
@@ -68,6 +69,7 @@ import { ContributeComponent } from './components/settings/contribute/contribute
     TvshowInformationComponent,
     EpisodeComponent,
     RemoteComponent,
+    ModalComponent,
     PlaylistItemComponent,
     SearchComponent,
     SearchbarComponent,
@@ -125,7 +127,7 @@ import { ContributeComponent } from './components/settings/contribute/contribute
   ],
   bootstrap: [AppComponent],
   providers: [
-    
+
   ]
 })
 export class AppModule {

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,38 +1,35 @@
-<div class=" hidden sm:block fixed w-screen top-0 z-30">
+<div class="hidden sm:block fixed w-screen top-0 z-30 relative mb-4">
     <div class="bg-gray-800">
         <div class="flex h-16 relative w-11/12 m-auto items-center justify-between">
             <div class="flex items-center space-x-8 h-full text-lg font-semibold">
                 <a [ngClass]="{'text-primary': isRoute('movie')}" routerLink="/movies" class="header-button" translate>header.movies</a>
                 <a [ngClass]="{'text-primary': isRoute('tvshow')}" routerLink="/tvshows" class="header-button" translate>header.tvshows</a>
                 <a [ngClass]="{'text-primary': isRoute('music')}" routerLink="/musics" class="header-button" translate>header.musics</a>
-            </div>        
-            <div class="flex items-center justify-items-center space-x-8">        
+            </div>
+            <div class="flex items-center justify-items-center space-x-8">
                 <app-searchbar></app-searchbar>
-    
+
                 <button (click)="openPlayer()" [ngClass]="{'text-primary': application.showPlayer}" class="hidden sm:block header-button text-xl"><fa-icon [icon]="['far', 'play-circle']" class="toggle-player"></fa-icon></button>
-    
+
                 <a (click)="openRemote()" class="header-button text-xl"><fa-icon [icon]="['fas', 'mobile-alt']"></fa-icon></a>
                 <a [ngClass]="{'text-primary': isRoute('settings')}" routerLink="/settings" class="header-button text-xl"><fa-icon [icon]="['fas', 'cog']"></fa-icon></a>
             </div>
         </div>
     </div>
-    
+
     <div class="h-1 bg-gradient-to-b from-gray-900 to-transparent w-full"></div>
 </div>
 
 
 
-<div class="sm:hidden w-full fixed z-40">
+<div *ngIf="router.url !== '/remote'" class="sm:hidden w-full fixed z-40">
     <div class="px-2 py-2 bg-dark-gray">
         <app-searchbar  class=""></app-searchbar>
     </div>
     <div class="h-1 bg-gradient-to-b from-gray-900 to-transparent w-full"></div>
 </div>
 
-<div class="h-20"></div>
-
-    
-<app-player @modalAnimationReverse *ngIf="application.showPlayer" class="z-40 fixed bottom-0 left-0 w-screen h-screen sm:left-auto sm:bottom-auto sm:h-auto sm:w-full sm:right-4 sm:top-14 sm:mt-1"></app-player> 
+<app-player @modalAnimationReverse *ngIf="application.showPlayer" class="z-40 fixed bottom-0 left-0 w-screen h-screen sm:left-auto sm:bottom-auto sm:h-auto sm:w-full sm:right-4 sm:top-14 sm:mt-1"></app-player>
 
 
 <div class="sm:hidden w-full bg-dark-gray bottom-0 fixed z-30">
@@ -57,18 +54,21 @@
             <fa-icon [ngClass]="{'text-primary': isRoute('music')}" routerLink="/musics" class="header-button" [icon]="['fas', 'music']"></fa-icon>
         </div>
 
-        <button class="w-full text-center z-10 group relative">     
+        <button class="w-full text-center z-10 group relative">
             <fa-icon class="header-button" [icon]="['fas', 'bars']"></fa-icon>
             <div class="floating-button-top-right pointer-group-button">
                 <div class="floating-list">
-                    <button class="floating-button" *ngIf="player.isAvailable()" (click)="openRemote()" translate="">
+                    <button *ngIf="router.url === '/remote'" class="floating-button" routerLink="/search" translate="">
+                        header.search.search
+                    </button>
+                    <button class="floating-button" *ngIf="router.url !== '/remote' && player.isAvailable()" routerLink="/remote" translate="">
                         header.remote
                     </button>
                     <a [ngClass]="{'text-primary': isRoute('settings')}" routerLink="/settings" class="floating-button" translate="">
                         header.settings
-                    </a>                
+                    </a>
                 </div>
-            </div>   
-        </button>  
+            </div>
+        </button>
     </div>
 </div>

--- a/src/app/components/modal/modal.component.html
+++ b/src/app/components/modal/modal.component.html
@@ -1,0 +1,12 @@
+<div id="remote" (click)="clickBg($event)" class="w-screen h-screen z-20 float-left top-0 bottom-0 fixed sm:py-8 back bg-opacity-80 bg-dark-full">
+    <div class="z-50 opacity-100 h-full relative m-auto overflow-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-400 sm:rounded-lg bg-dark-gray w-full sm:w-11/12 md:w-5/6 lg:w-4/6 xl:w-7/12 custom-modal">
+
+        <button routerLink="/remote" (click)="close()" class="expand-button bg-dark-full z-20 w-12"><fa-icon [icon]="['fas', 'expand']"></fa-icon></button>
+        <button (click)="close()" class="close-button bg-dark-full z-20 w-12"><fa-icon [icon]="['fas', 'times']"></fa-icon></button>
+        <div class="py-4 px-8 text-center items-center flex-col w-full h-full">
+
+            <app-remote></app-remote>
+
+        </div>
+    </div>
+</div>

--- a/src/app/components/modal/modal.component.scss
+++ b/src/app/components/modal/modal.component.scss
@@ -1,0 +1,3 @@
+.remote-container button {
+    @apply w-full;
+}

--- a/src/app/components/modal/modal.component.spec.ts
+++ b/src/app/components/modal/modal.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ModalComponent } from './modal.component';
+
+describe('RemoteComponent', () => {
+  let component: ModalComponent;
+  let fixture: ComponentFixture<ModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ModalComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/modal/modal.component.ts
+++ b/src/app/components/modal/modal.component.ts
@@ -1,0 +1,46 @@
+import { DOCUMENT } from '@angular/common';
+import { Component, HostListener, Inject, OnInit } from '@angular/core';
+import { Location} from '@angular/common';
+import { PlayerService } from 'src/app/services/player.service';
+import { ApplicationService } from 'src/app/services/application.service';
+import { openCloseAnimation } from 'src/app/models/appAnimation';
+
+@Component({
+  selector: 'remote-modal',
+  templateUrl: './modal.component.html',
+  styleUrls: ['./modal.component.scss'],
+  animations: [
+    openCloseAnimation
+  ],
+})
+export class ModalComponent implements OnInit {
+
+  constructor(public application: ApplicationService, @Inject(DOCUMENT) private document: Document, private location:Location, public player:PlayerService) {
+
+  }
+
+  ngOnInit(): void {
+    this.document.body.style.overflow = "hidden";
+    this.application.historyPush("remote");
+  }
+
+  ngOnDestroy(): void {
+    this.document.body.style.overflow = "overlay";
+  }
+
+  clickBg(event:any){
+    if(event.target.classList.contains('back')){
+      this.close();
+    }
+  }
+
+  close() {
+    this.application.openRemote = false;
+  }
+
+  @HostListener('window:popstate', ['$event'])
+  onPopState(event:Event) {
+    this.close();
+  }
+
+}

--- a/src/app/components/remote/remote.component.html
+++ b/src/app/components/remote/remote.component.html
@@ -1,71 +1,62 @@
-<div (click)="clickBg($event)" class="w-screen h-screen z-20 float-left top-0 bottom-0 fixed sm:py-8 back bg-opacity-80 bg-dark-full">
-    <div class="z-50 opacity-100 h-full relative m-auto overflow-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-gray-400 sm:rounded-lg bg-dark-gray w-full sm:w-11/12 md:w-5/6 lg:w-4/6 xl:w-7/12 custom-modal">             
- 
-        <button  (click)="close()" class="close-button bg-dark-full z-20 w-12"><fa-icon [icon]="['fas', 'times']"></fa-icon></button>
-        <div class="py-4 px-8 text-center items-center flex-col w-full h-full">
-            
-            <div class="flex flex-col items-center h-full w-full max-w-sm m-auto text-3xl space-y-2 remote-container">
-                
-                <div class="flex flex-col items-center h-full w-full bg-dark-full rounded-xl m-auto space-y-4 py-4 opacity-80  overflow-auto scrollbar-hide"  style="max-height: 750px;">
-                    <div class="px-2 w-full mt-4">
-                        <form class="bg-dark-full w-full rounded-lg text-white border border-1 border-gray-400 hover:border-gray-500 focus:border-gray-700 duration-300 flex items-center">
-                            <input name="textInput" [(ngModel)]="sendTextValue" (ngModelChange)="modelChangeFn($event)" class="bg-dark-full border-none focus:ring-0 focus:border-transparent w-full rounded-xl" type="text" placeholder="{{ 'remote.sendText' | translate }}">
-                            <button style="width: auto;" class="flex-shrink-0 hover:text-primary text-sm mr-4" type="submit" (click)="sendText()">
-                                <fa-icon class="flex items-center float-right text-xs" [icon]="['fas', 'paper-plane']"></fa-icon>
-                            </button>
-                        </form>
-                    </div>
-                    <div class="flex flex-row w-full h-full items-center">
-                        <button><fa-icon [icon]="['fas', 'align-left']" class="button-primary" (click)="onInputMenu()"></fa-icon></button>
-                        <button><fa-icon [icon]="['fas', 'home']" class="button-primary" (click)="onInputHome()"></fa-icon></button>
-                        <button><fa-icon [icon]="['fas', 'info-circle']" class="button-primary" (click)="onInputInfo()"></fa-icon></button>
-                    </div>
-                    <div class="flex flex-col w-full">
-                        <div class="flex flex-row w-full h-full items-center">
-                            <button><fa-icon [icon]="['fas', 'volume-down']" class="button-primary" (click)="onInputVolumeDown()"></fa-icon></button>
-                            <button></button>
-                            <button><fa-icon [icon]="['fas', 'volume-up']" class="button-primary" (click)="onInputVolumeUp()"></fa-icon></button>
-                        </div>
-                        <div [ngClass]="{'opacity-100' : displayVolumeBar}" class="relative pt-1 w-full px-8 mt-2 opacity-0 transition-opacity duration-100">
-                            <div class="overflow-hidden h-2 mb-4 text-xs flex rounded bg-pink-200">
-                            <div [ngStyle]="{'width': application.volume + '%'}" class="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-pink-500"></div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="w-9/12">
-                        <div class="aspect-w-4 aspect-h-3 text-4xl">
-                            <div class="flex flex-col items-center w-full h-full">
-                        
-                                <div class="flex flex-row w-full h-full items-center">
-                                    <button></button>
-                                    <button><fa-icon [icon]="['fas', 'sort-up']" class="button-primary" (click)="onInputUp()"></fa-icon></button>
-                                    <button></button>
-                                </div>
-                        
-                                <div class="flex flex-row w-full h-full items-center">
-                                    <button><fa-icon [icon]="['fas', 'caret-left']" class="button-primary" (click)="onInputLeft()"></fa-icon></button>
-                                    <button><fa-icon [icon]="['fas', 'dot-circle']" class="button-primary" (click)="onInputSelect()"></fa-icon></button>
-                                    <button><fa-icon [icon]="['fas', 'caret-right']" class="button-primary" (click)="onInputRight()"></fa-icon></button>
-                                </div>
-                        
-                                <div class="flex flex-row w-full h-full items-center">
-                                    <button></button>
-                                    <button><fa-icon [icon]="['fas', 'sort-down']" class="button-primary" (click)="onInputDown()"></fa-icon></button>
-                                    <button></button>
-                                </div>
-                            </div>
-                        </div>
-                    </div>       
-                
-                    <div class="flex flex-row w-full h-full items-center">
-                        <button><fa-icon [icon]="['fas', 'arrow-left']" class="button-primary" (click)="onInputBack()"></fa-icon></button>
-                        <button></button>
-                        <button><fa-icon [icon]="['fas', 'bars']" class="button-primary" (click)="onInputContextMenu()"></fa-icon></button>
-                    </div>   
-                    
-                </div>                
+<div id="remote" class="flex flex-col justify-around items-center h-full w-full max-w-sm m-auto text-3xl space-y-2 py-2 scrollbar-hide overflow-auto">
+
+    <div class="px-2 w-full mt-4">
+        <form class="bg-dark-full w-full rounded-lg text-white border border-1 border-gray-400 hover:border-gray-500 focus:border-gray-700 duration-300 flex items-center">
+            <input name="textInput" [(ngModel)]="sendTextValue" (ngModelChange)="modelChangeFn($event)" class="bg-dark-full border-none focus:ring-0 focus:border-transparent w-full rounded-xl" type="text" placeholder="{{ 'remote.sendText' | translate }}">
+            <button style="width: auto;" class="flex-shrink-0 hover:text-primary text-sm mr-4" type="submit" (click)="sendText()">
+                <fa-icon class="flex items-center float-right text-xs" [icon]="['fas', 'paper-plane']"></fa-icon>
+            </button>
+        </form>
+    </div>
+
+    <div class="flex flex-row w-full h-full items-center">
+        <button (click)="onInputMenu()"><fa-icon [icon]="['fas', 'align-left']" class="button-primary"></fa-icon></button>
+        <button (click)="onInputHome()"><fa-icon [icon]="['fas', 'home']" class="button-primary"></fa-icon></button>
+        <button (click)="onInputInfo()"><fa-icon [icon]="['fas', 'info-circle']" class="button-primary"></fa-icon></button>
+    </div>
+
+    <div class="flex flex-col h-full w-full">
+        <div class="flex flex-row w-full h-full items-center">
+            <button (click)="onInputVolumeDown()"><fa-icon [icon]="['fas', 'volume-down']" class="button-primary"></fa-icon></button>
+            <button></button>
+            <button (click)="onInputVolumeUp()"><fa-icon [icon]="['fas', 'volume-up']" class="button-primary"></fa-icon></button>
+        </div>
+        <div [ngClass]="{'opacity-100' : displayVolumeBar}" class="relative pt-1 w-full px-8 mt-2 opacity-0 transition-opacity duration-100">
+            <div class="overflow-hidden h-2 mb-4 text-xs flex rounded bg-pink-200">
+            <div [ngStyle]="{'width': application.volume + '%'}" class="shadow-none flex flex-col text-center whitespace-nowrap text-white justify-center bg-pink-500"></div>
             </div>
-            
         </div>
     </div>
+
+    <div class="w-9/12 h-full">
+        <div class="aspect-w-4 aspect-h-3 h-full text-4xl">
+            <div id="nav" class="flex flex-col items-center w-full h-full">
+
+                <div class="flex flex-row w-full h-full mb-4 items-center">
+                    <button></button>
+                    <button class="nav" (click)="onInputUp()"><fa-icon [icon]="['fas', 'angle-up']" class="button-primary fa-2xl"></fa-icon></button>
+                    <button></button>
+                </div>
+
+                <div class="flex flex-row w-full h-full items-center">
+                    <button class="nav" (click)="onInputLeft()"><fa-icon [icon]="['fas', 'angle-left']" class="button-primary fa-2xl"></fa-icon></button>
+                    <button class="nav" (click)="onInputSelect()"><fa-icon [icon]="['fas', 'dot-circle']" class="button-primary" style="font-size: 3rem;"></fa-icon></button>
+                    <button class="nav" (click)="onInputRight()"><fa-icon [icon]="['fas', 'angle-right']" class="button-primary fa-2xl"></fa-icon></button>
+                </div>
+
+                <div class="flex flex-row w-full h-full mt-4 items-center">
+                    <button></button>
+                    <button class="nav" (click)="onInputDown()"><fa-icon [icon]="['fas', 'angle-down']" class="button-primary fa-2xl"></fa-icon></button>
+                    <button></button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="bottom" class="flex flex-row w-full h-full items-center">
+        <button (click)="onInputBack()"><fa-icon [icon]="['fas', 'arrow-left']" class="button-primary"></fa-icon></button>
+        <button></button>
+        <button (click)="onInputContextMenu()"><fa-icon [icon]="['fas', 'bars']" class="button-primary"></fa-icon></button>
+    </div>
+
 </div>

--- a/src/app/components/remote/remote.component.scss
+++ b/src/app/components/remote/remote.component.scss
@@ -1,3 +1,21 @@
-.remote-container button {
-    @apply w-full;
+#remote {
+  max-height: 750px;
+}
+
+#remote button {
+    width: 100%;
+    height: 100%
+}
+
+#bottom {
+  margin-top: auto;
+  margin-bottom: 3rem;
+}
+
+button.nav {
+  height: 100%;
+}
+
+#nav fa-icon {
+  font-size: 5rem;
 }

--- a/src/app/components/remote/remote.component.ts
+++ b/src/app/components/remote/remote.component.ts
@@ -1,12 +1,13 @@
 import { DOCUMENT } from '@angular/common';
 import { Component, HostListener, Inject, OnInit } from '@angular/core';
-import { Location} from '@angular/common'; 
+import { Location} from '@angular/common';
 import { PlayerService } from 'src/app/services/player.service';
 import { ApplicationService } from 'src/app/services/application.service';
 import { openCloseAnimation } from 'src/app/models/appAnimation';
 import { KodiApiService } from 'src/app/services/kodi-api.service';
 import { interval, Subscription } from 'rxjs';
 import { LocalStorageService } from 'src/app/services/local-storage.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-remote',
@@ -24,32 +25,14 @@ export class RemoteComponent implements OnInit {
   sendTextValue = ""
   private subscriptionIncrementProgress!: Subscription;
 
-  constructor(public application: ApplicationService, private localStorage: LocalStorageService, private kodiApi: KodiApiService, @Inject(DOCUMENT) private document: Document, private location:Location, public player:PlayerService) {
+  constructor(public application: ApplicationService, private localStorage: LocalStorageService, private kodiApi: KodiApiService, @Inject(DOCUMENT) private document: Document, private location:Location, public player:PlayerService, private router: Router) {
 
   }
 
   ngOnInit(): void {
-    this.document.body.style.overflow = "hidden";  
-    this.application.historyPush("remote");
   }
 
   ngOnDestroy(): void {
-    this.document.body.style.overflow = "overlay";
-  }
-
-  clickBg(event:any){
-    if(event.target.classList.contains('back')){
-      this.close();
-    }
-  }
-
-  close() {
-    this.application.openRemote = false;  
-  }
-
-  @HostListener('window:popstate', ['$event'])
-  onPopState(event:Event) {
-    this.close();
   }
 
   onInputBack(){
@@ -135,7 +118,7 @@ export class RemoteComponent implements OnInit {
   private vibrate(){
     const vibrationLength:number = this.localStorage.getData("vibrate") ?? 50
     if(vibrationLength > 0)
-      window.navigator.vibrate(vibrationLength); 
+      window.navigator.vibrate(vibrationLength);
   }
 
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,6 +3,10 @@
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
+html, body {
+    height: 100%;
+}
+
 body {
     color:white;
     overflow: overlay;
@@ -97,7 +101,7 @@ button:focus, button:active:focus, button.active:focus {
             position: absolute;
             padding-top:4px;
         }
-    
+
         .floating-button-right {
             top: 0;
             position: absolute;
@@ -105,14 +109,14 @@ button:focus, button:active:focus, button.active:focus {
             left: 100%;
             padding-top:0;
         }
-    
+
         .floating-button-bottom-right {
             right:0;
             top:100%;
             position: absolute;
             padding-top:4px;
         }
-    
+
         .floating-button-top-right {
             right:0;
             bottom:100%;
@@ -137,13 +141,13 @@ button:focus, button:active:focus, button.active:focus {
 
         .floating-button {
             @apply block whitespace-nowrap px-3 py-2.5 w-full font-semibold bg-dark-gray bg-opacity-100 hover:bg-gray-500 transition-all duration-300 text-sm group-hover:pointer-events-auto group-focus:pointer-events-auto pointer-events-none;
-        
+
             * {
                 @apply cursor-pointer group-hover:pointer-events-auto group-focus:pointer-events-auto pointer-events-none;
             }
         }
     }
-   
+
 }
 
 body::-webkit-scrollbar {
@@ -153,6 +157,9 @@ body::-webkit-scrollbar {
 
 .close-button {
     @apply p-3 rounded-full opacity-80 hover:opacity-100 transition-opacity absolute top-3 right-3 cursor-pointer;
+}
+.expand-button {
+    @apply p-3 rounded-full opacity-80 hover:opacity-100 transition-opacity absolute top-3 right-16 cursor-pointer;
 }
 
 .button-media-watched {


### PR DESCRIPTION
These changes move the modal part of the remote to its own component (so existing functionality isn't removed). This allows the remote to be exposed under a dedicated route (so, e.g., a web app can open directly to the remote on a mobile device).

I've also increased the size (and click area) of some of the buttons so they're easier to hit without looking.

| before | after |
| -------- | ------ |
| ![Screenshot 2022-06-29 at 21-34-04 TeX - Web Interface for Kodi](https://user-images.githubusercontent.com/32495955/176574181-2d0d581b-a000-4578-87f4-0dccd4fadc33.png) | ![Screenshot 2022-06-29 at 21-33-10 TeX - Web Interface for Kodi](https://user-images.githubusercontent.com/32495955/176574204-534c698e-2209-4f56-926b-fa2c3f605fd8.png) |

I did make some minor edits to the header to avoid extra spacing on a small screen; in my basic testing, it doesn't appear to have changed the other pages.