### PR TITLE
wss:// if behind ssl load balancer

### DIFF
--- a/src/app/services/kodiwebsocket.service.ts
+++ b/src/app/services/kodiwebsocket.service.ts
@@ -57,7 +57,7 @@ export class KodiwebsocketService {
   }
 
   private getSocketUrl(): string {
-    return "ws://" + this.getAddress() + ":" + this.getPort() + "/jsonrpc"
+    return window.location.protocol.replace("http","ws")+"//" + this.getAddress() + ":" + this.getPort() + "/jsonrpc"
   }
 
   public connect(): void {


### PR DESCRIPTION
I am using TeX behind HAPproxy that terminates SSL. TeX is configured to use http protocol. As browsers open the UI on https, they refuse the unencrypted ws:// protocol. With this commit, the javascript uses wss:// if the frontend runs on https.