### PR TITLE
Placeholder for loading poster images to match rest of loading UI

### DIFF
--- a/src/app/components/utils/mediacard/mediacard.component.html
+++ b/src/app/components/utils/mediacard/mediacard.component.html
@@ -1,8 +1,10 @@
 <button class="p-1 sm:p-2 rounded-xl border-0" (click)="openDetails()" style="width:inherit">
     <div class="select-none rounded-xl">
         <div class="relative opacity-90 w-full rounded-xl" [ngClass]="{'h-24 bg-dark-gray hover:bg-gray-500' : posterUrl == '' && isImgLoaded}">
-            <img *ngIf="posterLoaded" [ngClass]="{'border-b border-primary' : displayResume && isImgLoaded}" [src]="posterUrl" (load)="imageLoaded()" class="rounded-xl w-full" loading="lazy">
-            
+          <div [ngClass]="{'image-placeholder': !isImgLoaded}">
+            <img *ngIf="posterLoaded" [ngClass]="{'border-b border-primary' : displayResume && isImgLoaded}" [src]="posterUrl" (load)="imageLoaded()" class="rounded-xl w-full" loading="lazy"/>
+          </div>
+
             <div [ngClass]="{'opacity-0': posterUrl != '' || !isImgLoaded, 'bg-dark-full' : !(posterUrl == '' && isImgLoaded)}" class="rounded-xl cursor-pointer absolute z-0 flex flex-col align-bottom  bottom-0 bg-opacity-70 hover:opacity-100 transition-opacity duration-300 text-white font-semibold px-3 py-1 h-full w-full items-center justify-center text-center text-shadow-xl overflow-auto scrollbar-hide">
                 <p class="">
                     {{ $any(media).title ?? $any(media).artist ?? $any(media).name ?? $any(media) ?? "" }}

--- a/src/app/components/utils/mediacard/mediacard.component.scss
+++ b/src/app/components/utils/mediacard/mediacard.component.scss
@@ -1,0 +1,6 @@
+.image-placeholder {
+  height: 13em;
+  display: block;
+  animation: loadPlaceholder 1s infinite ease-in-out;
+  border-radius: 0.75rem;
+}


### PR DESCRIPTION
While poster images are loading in in media cards, I made an animated pulsing gray background with the same size and corner radius and so on that the poster will have, that uses the loading placeholder animation used in other parts of the UI. It's just slightly nicer/more consistant.